### PR TITLE
fix: Don't print environment variables when VU context is shown

### DIFF
--- a/lib/formatters.js
+++ b/lib/formatters.js
@@ -41,7 +41,7 @@ function prettyPrint(requestExpectations, req, res, userContext) {
       console.log(prepend(String(JSON.stringify(res.body, null, 2)), '    '));
 
       console.log(chalk.yellow('  User variables:'));
-      Object.keys(userContext.vars).forEach(function(varName) {
+      Object.keys(userContext.vars).filter(varName => varName !== '$processEnvironment').forEach(function(varName) {
         console.log('    ', varName, ':', userContext.vars[varName]);
       });
     } else {


### PR DESCRIPTION
Ref: https://github.com/shoreditch-ops/artillery/commit/33ab0de492951d6f4e1fcbfde64a8b7c11f96130